### PR TITLE
Implement clip planes

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1070,12 +1070,29 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE Direct3DDevice9Ex::SetClipPlane(DWORD Index, const float* pPlane) {
-    Logger::warn("Direct3DDevice9Ex::SetClipPlane: Stub");
+    if (Index >= caps::MaxClipPlanes || !pPlane)
+      return D3DERR_INVALIDCALL;
+    
+    bool dirty = false;
+    
+    for (uint32_t i = 0; i < 4; i++) {
+      dirty |= m_state.clipPlanes[Index].coeff[i] != pPlane[i];
+      m_state.clipPlanes[Index].coeff[i] = pPlane[i];
+    }
+    
+    if (dirty)
+      m_flags.set(D3D9DeviceFlag::DirtyClipPlanes);
+    
     return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE Direct3DDevice9Ex::GetClipPlane(DWORD Index, float* pPlane) {
-    Logger::warn("Direct3DDevice9Ex::GetClipPlane: Stub");
+    if (Index >= caps::MaxClipPlanes || !pPlane)
+      return D3DERR_INVALIDCALL;
+    
+    for (uint32_t i = 0; i < 4; i++)
+      pPlane[i] = m_state.clipPlanes[Index].coeff[i];
+    
     return D3D_OK;
   }
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2975,29 +2975,17 @@ namespace dxvk {
 
   void Direct3DDevice9Ex::CreateConstantBuffers() {
     DxvkBufferCreateInfo info;
-    info.size  = D3D9ConstantSets::SetSize;
-
-    info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT
-               | VK_BUFFER_USAGE_TRANSFER_DST_BIT
-               | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-
-    info.stages = VK_PIPELINE_STAGE_TRANSFER_BIT
-                | VK_PIPELINE_STAGE_HOST_BIT;
-
-    info.access = VK_ACCESS_TRANSFER_READ_BIT
-                | VK_ACCESS_TRANSFER_WRITE_BIT
-                | VK_ACCESS_UNIFORM_READ_BIT
-                | VK_ACCESS_HOST_WRITE_BIT;
+    info.size   = D3D9ConstantSets::SetSize;
+    info.usage  = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+    info.access = VK_ACCESS_UNIFORM_READ_BIT;
+    info.stages = VK_PIPELINE_STAGE_VERTEX_SHADER_BIT
+                | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 
     VkMemoryPropertyFlags memoryFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
                                       | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
                                       | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 
-    info.stages |=  VK_PIPELINE_STAGE_VERTEX_SHADER_BIT;
     m_vsConst.buffer = m_dxvkDevice->createBuffer(info, memoryFlags);
-    info.stages &= ~VK_PIPELINE_STAGE_VERTEX_SHADER_BIT;
-
-    info.stages |=  VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
     m_psConst.buffer = m_dxvkDevice->createBuffer(info, memoryFlags);
 
     auto BindConstantBuffer = [this](

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2989,7 +2989,8 @@ namespace dxvk {
                 | VK_ACCESS_UNIFORM_READ_BIT
                 | VK_ACCESS_HOST_WRITE_BIT;
 
-    VkMemoryPropertyFlags memoryFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
+    VkMemoryPropertyFlags memoryFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
+                                      | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
                                       | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 
     info.stages |=  VK_PIPELINE_STAGE_VERTEX_SHADER_BIT;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1145,6 +1145,10 @@ namespace dxvk {
           m_flags.set(D3D9DeviceFlag::DirtyRasterizerState);
           break;
 
+        case D3DRS_CLIPPLANEENABLE:
+          m_flags.set(D3D9DeviceFlag::DirtyClipPlanes);
+          break;
+
         default:
           Logger::warn(str::format("Direct3DDevice9Ex::SetRenderState: Unhandled render state ", State));
           break;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -675,6 +675,8 @@ namespace dxvk {
       UploadConstants(DxsoProgramType::VertexShader);
       UploadConstants(DxsoProgramType::PixelShader);
     }
+    
+    void UpdateClipPlanes();
 
     Rc<DxvkSampler> CreateSampler(DWORD Sampler);
 
@@ -772,6 +774,8 @@ namespace dxvk {
 
     D3D9ConstantSets                m_vsConst;
     D3D9ConstantSets                m_psConst;
+
+    Rc<DxvkBuffer>                  m_vsClipPlanes;
 
     const D3D9VkFormatTable         m_d3d9Formats;
     const D3D9Options               m_d3d9Options;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -37,6 +37,7 @@ namespace dxvk {
   class D3D9Initializer;
 
   enum class D3D9DeviceFlag : uint64_t {
+    DirtyClipPlanes,
     DirtyDepthStencilState,
     DirtyBlendState,
     DirtyRasterizerState,

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -30,8 +30,8 @@ namespace dxvk {
         renderTargets[i] = nullptr;
 
       depthStencil = nullptr;
-	  vertexShader = nullptr;
-	  pixelShader = nullptr;
+      vertexShader = nullptr;
+      pixelShader = nullptr;
       vertexDecl = nullptr;
       indices = nullptr;
     }

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -13,6 +13,10 @@ namespace dxvk {
   class Direct3DVertexDeclaration9;
   class Direct3DVertexBuffer9;
   class Direct3DIndexBuffer9;
+  
+  struct D3D9ClipPlane {
+    float coeff[4];
+  };
 
   struct D3D9VBO {
     D3D9VBO() {
@@ -34,6 +38,9 @@ namespace dxvk {
       pixelShader = nullptr;
       vertexDecl = nullptr;
       indices = nullptr;
+      
+      for (uint32_t i = 0; i < clipPlanes.size(); i++)
+        clipPlanes[i] = D3D9ClipPlane();
     }
 
     std::array<Direct3DSurface9*, caps::MaxSimultaneousRenderTargets> renderTargets;
@@ -57,6 +64,8 @@ namespace dxvk {
 
     D3D9ShaderConstants vsConsts;
     D3D9ShaderConstants psConsts;
+    
+    std::array<D3D9ClipPlane, caps::MaxClipPlanes> clipPlanes;
     
   };
 

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -1135,6 +1135,15 @@ namespace dxvk {
     return m_regs[m_regs.size() - 1];
   }
 
+  DxsoSpirvRegister DxsoCompiler::findBuiltInOutputPtr(DxsoUsage usage) {
+    for (uint32_t i = 0; i < m_oDecls.size(); i++) {
+      if (m_oDecls[i].semantic.usage == usage)
+        return DxsoSpirvRegister { m_oDecls[i].id, m_oPtrs[i] };
+    }
+    
+    return DxsoSpirvRegister();
+  }
+
   uint32_t DxsoCompiler::getTypeId(DxsoRegisterType regType, uint32_t count) {
     switch (regType) {
     case DxsoRegisterType::Addr: {

--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -137,6 +137,8 @@ namespace dxvk {
 
     void emitVsFinalize();
     void emitPsFinalize();
+    
+    void emitVsClipping();
 
     void emitOutputDepthClamp();
 

--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -193,6 +193,8 @@ namespace dxvk {
       return getSpirvRegister(reg).varId;
     }
     DxsoSpirvRegister& mapSpirvRegister(DxsoRegisterId id, bool centroid, DxsoRegister* relative, const DxsoDeclaration* optionalPremadeDecl);
+    
+    DxsoSpirvRegister findBuiltInOutputPtr(DxsoUsage usage);
 
     uint32_t getTypeId(DxsoRegisterType regType, uint32_t count = 4);
     uint32_t spvType(const DxsoRegister& reg, uint32_t count = 4) {


### PR DESCRIPTION
Implements clipping planes in vertex shaders so that `clipDist = dot(clipPlane, vertexPos)`. This fixes some broken water reflections in Half-Life 2.

The first three patches are minor fixes around uniform buffers.