### PR TITLE
Implement Alpha Test

### DIFF
--- a/src/d3d11/d3d11_blend.cpp
+++ b/src/d3d11/d3d11_blend.cpp
@@ -20,7 +20,6 @@ namespace dxvk {
     // Multisample state is part of the blend state in D3D11
     m_msState.sampleMask            = 0; // Set during bind
     m_msState.enableAlphaToCoverage = desc.AlphaToCoverageEnable;
-    m_msState.enableAlphaToOne      = VK_FALSE;
     
     // Vulkan only supports a global logic op for the blend
     // state, which might be problematic in some cases.

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -596,7 +596,6 @@ namespace dxvk {
     
     m_msState.sampleMask            = 0xffffffff;
     m_msState.enableAlphaToCoverage = VK_FALSE;
-    m_msState.enableAlphaToOne      = VK_FALSE;
     
     VkStencilOpState stencilOp;
     stencilOp.failOp      = VK_STENCIL_OP_KEEP;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -62,7 +62,6 @@ namespace dxvk {
 
       DxvkMultisampleState msState;
       msState.sampleMask            = 0xffffffff;
-      msState.enableAlphaToOne      = VK_FALSE;
       msState.enableAlphaToCoverage = VK_FALSE;
       ctx->setMultisampleState(msState);
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -69,6 +69,10 @@ namespace dxvk {
       loState.enableLogicOp = VK_FALSE;
       loState.logicOp       = VK_LOGIC_OP_CLEAR;
       ctx->setLogicOpState(loState);
+      
+      DxvkExtraState xsState;
+      xsState.alphaCompareOp = VK_COMPARE_OP_ALWAYS;
+      ctx->setExtraState(xsState);
     });
 
     CreateConstantBuffers();
@@ -1118,6 +1122,11 @@ namespace dxvk {
         case D3DRS_SRCBLEND:
         case D3DRS_SRCBLENDALPHA:
           m_flags.set(D3D9DeviceFlag::DirtyBlendState);
+          break;
+        
+        case D3DRS_ALPHATESTENABLE:
+        case D3DRS_ALPHAFUNC:
+          m_flags.set(D3D9DeviceFlag::DirtyExtraState);
           break;
 
         case D3DRS_BLENDFACTOR:
@@ -3316,6 +3325,22 @@ namespace dxvk {
     });
   }
 
+  void Direct3DDevice9Ex::BindExtraState() {
+    m_flags.clr(D3D9DeviceFlag::DirtyExtraState);
+    
+    auto& rs = m_state.renderStates;
+    
+    VkCompareOp alphaOp = rs[D3DRS_ALPHATESTENABLE]
+      ? DecodeCompareOp(D3DCMPFUNC(rs[D3DRS_ALPHAFUNC]))
+      : VK_COMPARE_OP_ALWAYS;
+    
+    EmitCs([cAlphaOp = alphaOp] (DxvkContext* ctx) {
+      DxvkExtraState xs;
+      xs.alphaCompareOp = cAlphaOp;
+      ctx->setExtraState(xs);
+    });
+  }
+  
   void Direct3DDevice9Ex::BindDepthStencilRefrence() {
     auto& rs = m_state.renderStates;
 
@@ -3427,6 +3452,9 @@ namespace dxvk {
 
     if (m_flags.test(D3D9DeviceFlag::DirtyRasterizerState))
       BindRasterizerState();
+    
+    if (m_flags.test(D3D9DeviceFlag::DirtyExtraState))
+      BindExtraState();
     
     if (m_flags.test(D3D9DeviceFlag::DirtyClipPlanes))
       UpdateClipPlanes();

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1174,6 +1174,10 @@ namespace dxvk {
           m_flags.set(D3D9DeviceFlag::DirtyClipPlanes);
           break;
 
+        case D3DRS_ALPHAREF:
+          m_flags.set(D3D9DeviceFlag::DirtyRenderStateBuffer);
+          break;
+
         default:
           Logger::warn(str::format("Direct3DDevice9Ex::SetRenderState: Unhandled render state ", State));
           break;
@@ -3019,6 +3023,9 @@ namespace dxvk {
 
     info.size = caps::MaxClipPlanes * sizeof(D3D9ClipPlane);
     m_vsClipPlanes = m_dxvkDevice->createBuffer(info, memoryFlags);
+    
+    info.size = sizeof(D3D9RenderStateInfo);
+    m_psRenderStates = m_dxvkDevice->createBuffer(info, memoryFlags);
 
     auto BindConstantBuffer = [this](
       DxsoProgramType     shaderStage,
@@ -3040,8 +3047,11 @@ namespace dxvk {
     BindConstantBuffer(DxsoProgramType::VertexShader, m_vsConst.buffer, DxsoConstantBuffers::VSConstantBuffer);
     BindConstantBuffer(DxsoProgramType::PixelShader,  m_psConst.buffer, DxsoConstantBuffers::PSConstantBuffer);
     BindConstantBuffer(DxsoProgramType::VertexShader, m_vsClipPlanes,   DxsoConstantBuffers::VSClipPlanes);
+    BindConstantBuffer(DxsoProgramType::PixelShader,  m_psRenderStates, DxsoConstantBuffers::PSRenderStates);
     
-    m_flags.set(D3D9DeviceFlag::DirtyClipPlanes);
+    m_flags.set(
+      D3D9DeviceFlag::DirtyClipPlanes,
+      D3D9DeviceFlag::DirtyRenderStateBuffer);
   }
 
   void Direct3DDevice9Ex::UploadConstants(DxsoProgramType ShaderStage) {
@@ -3086,6 +3096,24 @@ namespace dxvk {
     
     EmitCs([
       cBuffer = m_vsClipPlanes,
+      cSlice  = slice
+    ] (DxvkContext* ctx) {
+      ctx->invalidateBuffer(cBuffer, cSlice);
+    });
+  }
+  
+  void Direct3DDevice9Ex::UpdateRenderStateBuffer() {
+    m_flags.clr(D3D9DeviceFlag::DirtyRenderStateBuffer);
+    
+    auto& rs = m_state.renderStates;
+    
+    auto slice = m_psRenderStates->allocSlice();
+    auto dst = reinterpret_cast<D3D9RenderStateInfo*>(slice.mapPtr);
+    
+    dst->alphaRef = float(rs[D3DRS_ALPHAREF]) / 255.0f;
+    
+    EmitCs([
+      cBuffer = m_psRenderStates,
       cSlice  = slice
     ] (DxvkContext* ctx) {
       ctx->invalidateBuffer(cBuffer, cSlice);
@@ -3458,6 +3486,9 @@ namespace dxvk {
     
     if (m_flags.test(D3D9DeviceFlag::DirtyClipPlanes))
       UpdateClipPlanes();
+
+    if (m_flags.test(D3D9DeviceFlag::DirtyRenderStateBuffer))
+      UpdateRenderStateBuffer();
 
     UpdateConstants();
   }

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -42,6 +42,7 @@ namespace dxvk {
     DirtyBlendState,
     DirtyRasterizerState,
     DirtyExtraState,
+    DirtyRenderStateBuffer,
     ExtendedDevice,
     DeferViewportBinding
   };
@@ -681,6 +682,8 @@ namespace dxvk {
     
     void UpdateClipPlanes();
     
+    void UpdateRenderStateBuffer();
+    
     Rc<DxvkSampler> CreateSampler(DWORD Sampler);
 
     void BindSampler(DWORD Sampler);
@@ -779,6 +782,7 @@ namespace dxvk {
     D3D9ConstantSets                m_psConst;
 
     Rc<DxvkBuffer>                  m_vsClipPlanes;
+    Rc<DxvkBuffer>                  m_psRenderStates;
 
     const D3D9VkFormatTable         m_d3d9Formats;
     const D3D9Options               m_d3d9Options;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -41,6 +41,7 @@ namespace dxvk {
     DirtyDepthStencilState,
     DirtyBlendState,
     DirtyRasterizerState,
+    DirtyExtraState,
     ExtendedDevice,
     DeferViewportBinding
   };
@@ -658,7 +659,7 @@ namespace dxvk {
     void BindFramebuffer();
 
     void BindViewportAndScissor();
-
+    
     void BindBlendState();
 
     void BindBlendFactor();
@@ -669,6 +670,8 @@ namespace dxvk {
 
     void BindRasterizerState();
 
+    void BindExtraState();
+    
     void UploadConstants(DxsoProgramType ShaderStage);
 
     inline void UpdateConstants() {
@@ -677,7 +680,7 @@ namespace dxvk {
     }
     
     void UpdateClipPlanes();
-
+    
     Rc<DxvkSampler> CreateSampler(DWORD Sampler);
 
     void BindSampler(DWORD Sampler);

--- a/src/d3d9/d3d9_presenter.cpp
+++ b/src/d3d9/d3d9_presenter.cpp
@@ -209,7 +209,6 @@ namespace dxvk {
 
     m_msState.sampleMask = 0xffffffff;
     m_msState.enableAlphaToCoverage = VK_FALSE;
-    m_msState.enableAlphaToOne = VK_FALSE;
 
     VkStencilOpState stencilOp;
     stencilOp.failOp = VK_STENCIL_OP_KEEP;

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -18,6 +18,10 @@ namespace dxvk {
     float coeff[4];
   };
 
+  struct D3D9RenderStateInfo {
+    float alphaRef;
+  };
+  
   struct D3D9VBO {
     D3D9VBO() {
       vertexBuffer = nullptr;

--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -139,6 +139,7 @@ namespace dxvk {
     void emitPsFinalize();
     
     void emitVsClipping();
+    void emitPsProcessing();
 
     void emitOutputDepthClamp();
 
@@ -196,7 +197,7 @@ namespace dxvk {
     }
     DxsoSpirvRegister& mapSpirvRegister(DxsoRegisterId id, bool centroid, DxsoRegister* relative, const DxsoDeclaration* optionalPremadeDecl);
     
-    DxsoSpirvRegister findBuiltInOutputPtr(DxsoUsage usage);
+    DxsoSpirvRegister findBuiltInOutputPtr(DxsoUsage usage, uint32_t index);
 
     uint32_t getTypeId(DxsoRegisterType regType, uint32_t count = 4);
     uint32_t spvType(const DxsoRegister& reg, uint32_t count = 4) {

--- a/src/dxso/dxso_util.cpp
+++ b/src/dxso/dxso_util.cpp
@@ -30,10 +30,10 @@ namespace dxvk {
     }
     else { // Pixel Shader
       switch (bindingType) {
-      case DxsoBindingType::ConstantBuffer: return bindingIndex + stageOffset + 0;  // 0 + 1 = 1
+      case DxsoBindingType::ConstantBuffer: return bindingIndex + stageOffset + 0;  // 0 + 2 = 2
         // The extra sampler here is being reserved for DMAP stuff later on.
-      case DxsoBindingType::ImageSampler:   return bindingIndex + stageOffset + 1;  // 1 + 17 = 18
-      case DxsoBindingType::Image:          return bindingIndex + stageOffset + 18; // 18 + 17 = 35
+      case DxsoBindingType::ImageSampler:   return bindingIndex + stageOffset + 2;  // 2 + 17 = 19
+      case DxsoBindingType::Image:          return bindingIndex + stageOffset + 19; // 19 + 17 = 36
       default: Logger::err("computeResourceSlotId: Invalid resource type");
       }
     }

--- a/src/dxso/dxso_util.h
+++ b/src/dxso/dxso_util.h
@@ -23,6 +23,7 @@ namespace dxvk {
     VSCount,
 
     PSConstantBuffer = 0,
+    PSRenderStates   = 1,
     PSCount
   };
 

--- a/src/dxvk/dxvk_constant_state.h
+++ b/src/dxvk/dxvk_constant_state.h
@@ -180,4 +180,16 @@ namespace dxvk {
     std::array<DxvkVertexBinding,   DxvkLimits::MaxNumVertexBindings>   bindings;
   };
   
+  
+  /**
+   * \brief Extra state
+   * 
+   * Additional state that will be passed to
+   * the graphics pipeline as specialization
+   * constants.
+   */
+  struct DxvkExtraState {
+    VkCompareOp           alphaCompareOp;
+  };
+  
 }

--- a/src/dxvk/dxvk_constant_state.h
+++ b/src/dxvk/dxvk_constant_state.h
@@ -92,7 +92,6 @@ namespace dxvk {
   struct DxvkMultisampleState {
     uint32_t            sampleMask;
     VkBool32            enableAlphaToCoverage;
-    VkBool32            enableAlphaToOne;
   };
   
   

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1990,7 +1990,6 @@ namespace dxvk {
   void DxvkContext::setMultisampleState(const DxvkMultisampleState& ms) {
     m_state.gp.state.msSampleMask            = ms.sampleMask;
     m_state.gp.state.msEnableAlphaToCoverage = ms.enableAlphaToCoverage;
-    m_state.gp.state.msEnableAlphaToOne      = ms.enableAlphaToOne;
     
     m_flags.set(DxvkContextFlag::GpDirtyPipelineState);
   }

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2031,6 +2031,14 @@ namespace dxvk {
   }
 
 
+  void DxvkContext::setExtraState(
+    const DxvkExtraState&     xs) {
+    m_state.gp.state.xsAlphaCompareOp = xs.alphaCompareOp;
+    
+    m_flags.set(DxvkContextFlag::GpDirtyPipelineState);
+  }
+  
+  
   void DxvkContext::setPredicate(
     const DxvkBufferSlice&    predicate,
           VkConditionalRenderingFlagsEXT flags) {

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -814,6 +814,13 @@ namespace dxvk {
       const DxvkBlendMode&      blendMode);
     
     /**
+     * \brief Sets extra pipeline state
+     * \param [in] xs New state object
+     */
+    void setExtraState(
+      const DxvkExtraState&     xs);
+    
+    /**
      * \brief Sets predicate
      *
      * Enables or disables conditional rendering,

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -204,6 +204,8 @@ namespace dxvk {
     // Set up some specialization constants
     DxvkSpecConstantData specData;
     specData.rasterizerSampleCount = uint32_t(sampleCount);
+    specData.alphaTestEnable       = state.xsAlphaCompareOp != VK_COMPARE_OP_ALWAYS;
+    specData.alphaCompareOp        = state.xsAlphaCompareOp;
     
     for (uint32_t i = 0; i < MaxNumActiveBindings; i++)
       specData.activeBindings[i] = state.bsBindingMask.isBound(i) ? VK_TRUE : VK_FALSE;
@@ -353,7 +355,7 @@ namespace dxvk {
     msInfo.minSampleShading       = m_common.msSampleShadingFactor;
     msInfo.pSampleMask            = &state.msSampleMask;
     msInfo.alphaToCoverageEnable  = state.msEnableAlphaToCoverage;
-    msInfo.alphaToOneEnable       = state.msEnableAlphaToOne;
+    msInfo.alphaToOneEnable       = VK_FALSE;
     
     VkPipelineDepthStencilStateCreateInfo dsInfo;
     dsInfo.sType                  = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;

--- a/src/dxvk/dxvk_graphics.h
+++ b/src/dxvk/dxvk_graphics.h
@@ -92,7 +92,8 @@ namespace dxvk {
     VkSampleCountFlags                  msSampleCount;
     uint32_t                            msSampleMask;
     VkBool32                            msEnableAlphaToCoverage;
-    VkBool32                            msEnableAlphaToOne;
+    
+    VkCompareOp                         xsAlphaCompareOp;
     
     VkBool32                            dsEnableDepthTest;
     VkBool32                            dsEnableDepthWrite;

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -30,10 +30,12 @@ namespace dxvk {
     // Specialization constants for pipeline state
     SpecConstantRangeStart      = ColorComponentMappings + MaxNumRenderTargets * 4,
     RasterizerSampleCount       = SpecConstantRangeStart + 0,
+    AlphaTestEnable,
+    AlphaCompareOp,
 
     /// Lowest and highest known spec constant IDs
     SpecConstantIdMin           = RasterizerSampleCount,
-    SpecConstantIdMax           = RasterizerSampleCount,
+    SpecConstantIdMax           = AlphaCompareOp,
   };
   
   

--- a/src/dxvk/dxvk_spec_const.cpp
+++ b/src/dxvk/dxvk_spec_const.cpp
@@ -11,6 +11,8 @@ namespace dxvk {
   
   DxvkSpecConstantMap::DxvkSpecConstantMap() {
     SET_CONSTANT_ENTRY(DxvkSpecConstantId::RasterizerSampleCount, rasterizerSampleCount);
+    SET_CONSTANT_ENTRY(DxvkSpecConstantId::AlphaTestEnable,       alphaTestEnable);
+    SET_CONSTANT_ENTRY(DxvkSpecConstantId::AlphaCompareOp,        alphaCompareOp);
 
     for (uint32_t i = 0; i < MaxNumActiveBindings; i++)
       this->setBindingEntry(i);

--- a/src/dxvk/dxvk_spec_const.h
+++ b/src/dxvk/dxvk_spec_const.h
@@ -18,6 +18,8 @@ namespace dxvk {
    */
   struct DxvkSpecConstantData {
     uint32_t rasterizerSampleCount;
+    VkBool32 alphaTestEnable;
+    VkCompareOp alphaCompareOp;
     uint32_t outputMappings[MaxNumRenderTargets * 4];
     VkBool32 activeBindings[MaxNumActiveBindings];
   };


### PR DESCRIPTION
See title. Uses specialization constants to select the alpha compare op in the fragment shader, and passes in the alpha reference using a uniform buffer.

Some backend work was done to expose the alpha compare op to the shader without breaking existing D3D11 state caches, I'll cherry-pick that commit into mainline DXVK should you decide to merge this implementation.