### PR TITLE
Implement instancing

### DIFF
--- a/src/d3d9/d3d9_caps.cpp
+++ b/src/d3d9/d3d9_caps.cpp
@@ -19,7 +19,7 @@ namespace dxvk::caps {
       return D3DERR_NOTAVAILABLE;
 
     if (checkFormat == D3D9Format::INST)
-      return D3DERR_NOTAVAILABLE;
+      return D3D_OK;
 
     switch (resourceType) {
     case D3DRTYPE_SURFACE:

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -53,6 +53,8 @@ namespace dxvk {
       SamplerCount>                                  samplerStates;
 
     std::array<D3D9VBO, caps::MaxStreams>            vertexBuffers;
+    uint32_t                                         instanceCount = 1;
+    std::array<uint32_t, caps::MaxStreams>           instanceDataStepRates;
 
     std::array<
       IDirect3DBaseTexture9*,
@@ -122,7 +124,8 @@ namespace dxvk {
     ScissorRect,
     ClipPlanes,
     VsConstants,
-    PsConstants
+    PsConstants,
+    Instancing
   };
 
   using D3D9CapturedStateFlags = Flags<D3D9CapturedStateFlag>;
@@ -140,6 +143,9 @@ namespace dxvk {
     std::bitset<caps::MaxStreams>                       vertexBuffers;
     std::bitset<SamplerCount>                           textures;
     std::bitset<caps::MaxClipPlanes>                    clipPlanes;
+
+    std::bitset<caps::MaxStreams>                       instanceDataStepRates;
+    bool                                                instanceCount;
 
     struct {
       std::bitset<caps::MaxFloatConstants>              fConsts;

--- a/src/d3d9/d3d9_stateblock.cpp
+++ b/src/d3d9/d3d9_stateblock.cpp
@@ -96,6 +96,29 @@ namespace dxvk {
     return D3D_OK;
   }
 
+  HRESULT D3D9StateBlock::SetStreamSourceFreq(
+          UINT StreamNumber,
+          UINT Setting) {
+     if ((Setting & D3DSTREAMSOURCE_INDEXEDDATA) == D3DSTREAMSOURCE_INDEXEDDATA) {
+      m_state.instanceCount = Setting & ~D3DSTREAMSOURCE_INDEXEDDATA;
+      m_captures.instanceCount = true;
+     } else if ((Setting & D3DSTREAMSOURCE_INSTANCEDATA) == D3DSTREAMSOURCE_INSTANCEDATA) {
+      m_state.instanceDataStepRates[StreamNumber] = Setting & ~D3DSTREAMSOURCE_INSTANCEDATA;
+      m_captures.instanceDataStepRates[StreamNumber] = true;
+    } else {
+      if (StreamNumber == 0) {
+        m_state.instanceCount = 1;
+        m_captures.instanceCount = true;
+      }
+
+      m_state.instanceDataStepRates[StreamNumber] = 0;
+      m_captures.instanceDataStepRates[StreamNumber] = true;
+    }
+
+    m_captures.flags.set(D3D9CapturedStateFlag::Instancing);
+    return D3D_OK;
+  }
+
   HRESULT D3D9StateBlock::SetStateTexture(DWORD StateSampler, IDirect3DBaseTexture9* pTexture) {
     TextureChangePrivate(m_state.textures[StateSampler], pTexture);
 

--- a/src/d3d9/d3d9_stateblock.h
+++ b/src/d3d9/d3d9_stateblock.h
@@ -52,6 +52,8 @@ namespace dxvk {
             UINT                    OffsetInBytes,
             UINT                    Stride);
 
+    HRESULT STDMETHODCALLTYPE SetStreamSourceFreq(UINT StreamNumber, UINT Setting);
+
     HRESULT SetStateTexture(DWORD StateSampler, IDirect3DBaseTexture9* pTexture);
 
     HRESULT SetVertexShader(D3D9VertexShader* pShader);
@@ -204,6 +206,15 @@ namespace dxvk {
         }
 
         dst->SetPixelBoolBitfield(boolMask, src->psConsts.hardware.boolBitfield);
+      }
+
+      if (m_captures.flags.test(D3D9CapturedStateFlag::Instancing)) {
+        for (uint32_t i = 0; i < caps::MaxStreams; i++) {
+          if (m_captures.instanceDataStepRates[i])
+            dst->SetStreamSourceFreq(i, D3DSTREAMSOURCE_INSTANCEDATA | m_state.instanceDataStepRates[i]);
+        }
+        if (m_captures.instanceCount)
+          dst->SetStreamSourceFreq(0, D3DSTREAMSOURCE_INDEXEDDATA | m_state.instanceCount);
       }
     }
 


### PR DESCRIPTION
I'm still not sure this is 100% correct and covers all weird corner cases. It works for the sample that's included with the old DirectX SDK. I haven't tested the stateblock part of it. It should work though.
___

```
HRESULT SetStreamSourceFreq(
  UINT StreamNumber,
  UINT Divider
);
```
So here's my understanding of how it actually works: 

- Stream 0 can not be used with `D3DSTREAMSOURCE_INSTANCEDATA`
- Stream 1 and higher can not be used with `D3DSTREAMSOURCE_INDEXEDDATA`
- the value that gets or'd with `D3DSTREAMSOURCE_INDEXEDDATA` is the amount of instances that get rendered (has to be stream 0)
- the value that gets or'd with `D3DSTREAMSOURCE_INSTANCEDATA` is the amount of instances that share their per instance data (must not be stream 0)
- you can call SetStreamSourceFreq without either `D3DSTREAMSOURCE_INSTANCEDATA` or `D3DSTREAMSOURCE_INDEXEDDATA`. I'm not entirely sure what this does. The samples (and actual games) only use the value 1 for the Divider to disable instancing. It seems like D3D9 just ignores the actual value unless its 0 which results in D3DERR_INVALIDCALL.

What a mess.