### PR TITLE
[d3d9] Do not depend on dxgi/ directory

### DIFF
--- a/src/d3d9/d3d9_main.cpp
+++ b/src/d3d9/d3d9_main.cpp
@@ -1,5 +1,3 @@
-#include "../dxgi/dxgi_include.h"
-
 #include "../dxvk/dxvk_instance.h"
 
 #include "d3d9_interface.h"

--- a/src/d3d9/d3d9_presenter.cpp
+++ b/src/d3d9/d3d9_presenter.cpp
@@ -1,7 +1,7 @@
 #include "d3d9_presenter.h"
 
-#include "dxgi_presenter_frag.h"
-#include "dxgi_presenter_vert.h"
+#include "d3d9_presenter_frag.h"
+#include "d3d9_presenter_vert.h"
 
 namespace dxvk {
 
@@ -273,8 +273,8 @@ namespace dxvk {
 
 
   void D3D9Presenter::initShaders() {
-    const SpirvCodeBuffer vsCode(dxgi_presenter_vert);
-    const SpirvCodeBuffer fsCode(dxgi_presenter_frag);
+    const SpirvCodeBuffer vsCode(d3d9_presenter_vert);
+    const SpirvCodeBuffer fsCode(d3d9_presenter_frag);
 
     const std::array<DxvkResourceSlot, 2> fsResourceSlots = { {
       { BindingIds::Image,  VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,  VK_IMAGE_VIEW_TYPE_2D },

--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -1,3 +1,8 @@
+d3d9_shaders = files([
+  'shaders/d3d9_presenter_frag.frag',
+  'shaders/d3d9_presenter_vert.vert',
+])
+
 d3d9_src = [
   'd3d9_main.cpp',
   'd3d9_interface.cpp',
@@ -25,7 +30,7 @@ d3d9_src = [
   'd3d9_initializer.cpp'
 ]
 
-d3d9_dll = shared_library('d3d9'+dll_ext, d3d9_src, glsl_generator.process(dxgi_shaders),
+d3d9_dll = shared_library('d3d9'+dll_ext, d3d9_src, glsl_generator.process(d3d9_shaders),
   name_prefix         : '',
   dependencies        : [ dxso_dep, dxvk_dep ],
   include_directories : dxvk_include_path,

--- a/src/d3d9/shaders/d3d9_presenter_frag.frag
+++ b/src/d3d9/shaders/d3d9_presenter_frag.frag
@@ -1,0 +1,21 @@
+#version 450
+
+layout(constant_id = 1) const bool s_gamma_bound = true;
+
+layout(binding = 0) uniform sampler2D s_image;
+layout(binding = 1) uniform sampler1D s_gamma;
+
+layout(location = 0) in  vec2 i_texcoord;
+layout(location = 0) out vec4 o_color;
+
+void main() {
+  o_color = texture(s_image, i_texcoord);
+  
+  if (s_gamma_bound) {
+    o_color = vec4(
+      texture(s_gamma, o_color.r).r,
+      texture(s_gamma, o_color.g).g,
+      texture(s_gamma, o_color.b).b,
+      o_color.a);
+  }
+}

--- a/src/d3d9/shaders/d3d9_presenter_vert.vert
+++ b/src/d3d9/shaders/d3d9_presenter_vert.vert
@@ -1,0 +1,16 @@
+#version 450
+
+const vec4 g_vpos[4] = {
+  vec4(-1.0f, -1.0f, 0.0f, 1.0f),
+  vec4(-1.0f,  1.0f, 0.0f, 1.0f),
+  vec4( 1.0f, -1.0f, 0.0f, 1.0f),
+  vec4( 1.0f,  1.0f, 0.0f, 1.0f),
+};
+
+layout(location = 0) out vec2 o_texcoord;
+
+void main() {
+  vec4 pos = g_vpos[gl_VertexIndex];
+  o_texcoord  = 0.5f + 0.5f * pos.xy;
+  gl_Position = pos;
+}


### PR DESCRIPTION
* shaders copied from `dxgi/shaders`
* all mentions for `dxgi_` shaders renamed to `d3d9_`
* `dxgi_include.h` dropped, all required definitions already in `d3d9_include.h`

So `dxgi`, `dxbc`, `d3d11` and `d3d10` directories are optional now, can be ignored if user want to build just `d3d9.dll`.