### PR TITLE
[d3d9] Fix d3d9.presentInterval option behaviour

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -65,7 +65,7 @@
 # Supported values: Any non-negative number
 
 # dxgi.syncInterval   = -1
-# d3d9.presentInteral = -1
+# d3d9.presentInterval = -1
 
 
 # Enables or dsables d3d10 support.

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -81,11 +81,6 @@ namespace dxvk {
 
     uint32_t presentInterval = m_presentParams.PresentationInterval;
 
-    auto options = m_parent->GetOptions();
-
-    if (options->presentInterval >= 0)
-      presentInterval = options->presentInterval;
-
     // This is not true directly in d3d9 to to timing differences that don't matter for us.
     // For our purposes...
     // D3DPRESENT_INTERVAL_DEFAULT (0) == D3DPRESENT_INTERVAL_ONE (1) which means VSYNC.
@@ -93,6 +88,11 @@ namespace dxvk {
 
     if (presentInterval == D3DPRESENT_INTERVAL_IMMEDIATE || (dwFlags & D3DPRESENT_FORCEIMMEDIATE))
       presentInterval = 0;
+
+    auto options = m_parent->GetOptions();
+
+    if (options->presentInterval >= 0)
+      presentInterval = options->presentInterval;
 
     bool vsync  = presentInterval != 0;
 


### PR DESCRIPTION
Currently `d3d9.presentInterval` option ignored.
With this fix everithing work as expected, e.g. `d3d9.presentInterval = 0` means vsync off, and `d3d9.presentInterval = 2` means "vsync / 2"

Fixes #89