### PR TITLE
Add an option to disable read only locking

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3222,6 +3222,9 @@ namespace dxvk {
             DWORD                   Flags) {
     auto lock = LockDevice();
 
+    if (!m_d3d9Options.allowLockFlagReadonly)
+      Flags &= ~D3DLOCK_READONLY;
+
     UINT Subresource = pResource->CalcSubresource(Face, MipLevel);
     auto& desc = *(pResource->Desc());
 
@@ -3492,6 +3495,9 @@ namespace dxvk {
 
     if (unlikely(ppbData == nullptr))
       return D3DERR_INVALIDCALL;
+
+    if (!m_d3d9Options.allowLockFlagReadonly)
+      Flags &= ~D3DLOCK_READONLY;
 
     pResource->SetMapFlags(Flags);
 

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -34,6 +34,7 @@ namespace dxvk {
     this->shaderModel           = config.getOption<int32_t>("d3d9.shaderModel",     3);
     this->evictManagedOnUnlock  = config.getOption<bool>   ("d3d9.evictManagedOnUnlock", false);
     this->dpiAware              = config.getOption<bool>   ("d3d9.dpiAware", true);
+    this->allowLockFlagReadonly = config.getOption<bool>   ("d3d9.allowLockFlagReadonly", true);
     this->strictConstantCopies  = config.getOption<bool>   ("d3d9.strictConstantCopies", false);
     this->strictPow             = config.getOption<bool>   ("d3d9.strictPow",            true);
     this->lenientClear          = config.getOption<bool>   ("d3d9.lenientClear",         false);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -32,6 +32,11 @@ namespace dxvk {
 
     /// Whether or not to set the process as DPI aware in Windows when the API interface is created.
     bool dpiAware;
+    
+    /// Handle D3DLOCK_READONLY properly.
+    ///
+    /// Risen 1 writes to buffers mapped with readonly.
+    bool allowLockFlagReadonly;
 
     /// True:  Copy our constant set into UBO if we are relative indexing ever.
     /// False: Copy our constant set into UBO if we are relative indexing at the start of a defined constant

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -164,6 +164,10 @@ namespace dxvk {
       { "d3d9.strictPow",                   "False" },
       { "d3d9.lenientClear",                "True" },
     }} },
+    /* Risen                                      */
+    { "Risen.exe", {{
+      { "d3d9.allowLockFlagReadonly",       "False" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Risen 1 copies data to buffers that were locked as readonly and expects that to work. Because of this most of the game isn't renderer because the vertex/index data never gets copied to the gpu.

I decided to add a config option and allow readonly locking by default to avoid unnecessary copies in other games. Let's see if we find more games that are broken like this.