### PR TITLE
[d3d9] Extend RenderStateCount to 256

### DIFF
--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -9,7 +9,7 @@
 
 namespace dxvk {
 
-  static constexpr uint32_t RenderStateCount  = D3DRS_BLENDOPALPHA + 1;
+  static constexpr uint32_t RenderStateCount  = 256;
   static constexpr uint32_t SamplerStateCount = D3DSAMP_DMAPOFFSET + 1;
   static constexpr uint32_t SamplerCount      = 21;
 


### PR DESCRIPTION
With D3D9 you can apparently set render states up to the type 255.

I forgot to resize the array in my pr yesterday.