### PR TITLE
[d3d9] Add intermediate texture to avoid hazards

### DIFF
--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -744,7 +744,9 @@ namespace dxvk {
 
     void BindSampler(DWORD Sampler);
 
-    void BindTexture(DWORD SamplerSampler);
+    void BindTexture(
+      DWORD SamplerSampler,
+      bool  hazard);
 
     void UndirtySamplers();
 

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -50,8 +50,9 @@ namespace dxvk {
     // Decide whether we need to create a pass-through
     // geometry shader for vertex shader stream output
 
-    m_shader = pModule->compile(*pDxsoModuleInfo, name, AnalysisInfo);
-    m_isgn   = pModule->isgn();
+    m_shader       = pModule->compile(*pDxsoModuleInfo, name, AnalysisInfo);
+    m_isgn         = pModule->isgn();
+    m_usedSamplers = pModule->usedSamplers();
 
     m_meta      = pModule->meta();
     m_constants = pModule->constants();

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -46,9 +46,14 @@ namespace dxvk {
     const DxsoShaderMetaInfo& GetMeta() const { return m_meta; }
     const DxsoDefinedConstants& GetConstants() const { return m_constants; }
 
+    std::bitset<17> usedSamplers() const { return m_usedSamplers; }
+
   private:
 
     DxsoIsgn              m_isgn;
+
+    // Bit field containing used sampler slots
+    std::bitset<17>              m_usedSamplers;
 
     DxsoShaderMetaInfo    m_meta;
     DxsoDefinedConstants  m_constants;

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -625,6 +625,7 @@ namespace dxvk {
       m_resourceSlots.push_back(resource);
     };
 
+    m_usedSamplers[idx] = true;
     DclSampler(idx, type, false);
     DclSampler(idx, type, true);
 
@@ -634,6 +635,7 @@ namespace dxvk {
       DxsoBindingType::DepthImage, idx);
 
     DxsoSampler& sampler = m_samplers[idx];
+
 
     sampler.depthSpecConst = m_module.specConstBool(true);
     m_module.decorateSpecId(sampler.depthSpecConst, depthBinding);

--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -4,6 +4,7 @@
 #include "dxso_header.h"
 #include "dxso_modinfo.h"
 #include "dxso_isgn.h"
+#include <bitset>
 
 #include "../spirv/spirv_module.h"
 
@@ -215,6 +216,8 @@ namespace dxvk {
     const DxsoShaderMetaInfo& meta() { return m_meta; }
     const DxsoDefinedConstants& constants() { return m_constants; }
 
+    std::bitset<17> usedSamplers() const { return m_usedSamplers; }
+
   private:
 
     DxsoModuleInfo             m_moduleInfo;
@@ -312,6 +315,10 @@ namespace dxvk {
     // Shader-specific data structures
     DxsoCompilerVsPart m_vs;
     DxsoCompilerPsPart m_ps;
+
+    ///////////////////////////////////
+    // Bit field containing used sampler slots
+    std::bitset<17> m_usedSamplers;
 
     //////////////////////////////////////
     // Common function definition methods

--- a/src/dxso/dxso_module.cpp
+++ b/src/dxso/dxso_module.cpp
@@ -29,6 +29,7 @@ namespace dxvk {
 
     this->runCompiler(compiler, m_code.iter());
     m_isgn = compiler.isgn();
+    m_usedSamplers = compiler.usedSamplers();
 
     m_meta      = compiler.meta();
     m_constants = compiler.constants();

--- a/src/dxso/dxso_module.h
+++ b/src/dxso/dxso_module.h
@@ -8,6 +8,7 @@
 #include "dxso_isgn.h"
 #include "dxso_analysis.h"
 
+#include <bitset>
 #include <vector>
 
 namespace dxvk {
@@ -52,6 +53,8 @@ namespace dxvk {
 
     const DxsoDefinedConstants& constants() { return m_constants; }
 
+    std::bitset<17> usedSamplers() const { return m_usedSamplers; }
+
   private:
 
     void runCompiler(
@@ -69,6 +72,8 @@ namespace dxvk {
 
     DxsoShaderMetaInfo   m_meta;
     DxsoDefinedConstants m_constants;
+
+    std::bitset<17>      m_usedSamplers;
 
   };
 


### PR DESCRIPTION
This PR detects resource hazards before every draw and binds an intermediate texture as SRV instead of the actual texture. To do so, it copies the contents of the actual texture over before every draw, which is *less than ideal*.
We should write a test for d3d9 to figure out if its good enough to copy the actual texture over just once when it gets bound as an RT.
Another possible mitigation of the impact would be to unbind the RT when COLORWRITEENABLE is set to 0.
This also doesn't respect DEPTH_READ_ONLY yet.

According to Varris on Discord, this fixes the rendering of the Force Unleashed 2 trace on AMD.

I'd like to get some feedback on this. I don't know if this is ultimately faster than the linear tiling hack but at least this one is correct according to the Vulkan spec.