### PR TITLE
Include END in VertexDecl::GetDeclaration

### DIFF
--- a/src/d3d9/d3d9_vertex_declaration.cpp
+++ b/src/d3d9/d3d9_vertex_declaration.cpp
@@ -53,16 +53,16 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     if (pElement == nullptr) {
-      *pNumElements = m_elements.size();
+      *pNumElements = m_elements.size() + 1u; // include D3DDECL_END
       return D3D_OK;
     }
-
-    const UINT count = std::min(*pNumElements, UINT(m_elements.size()));
 
     std::memcpy(
       pElement,
       m_elements.data(),
-      sizeof(D3DVERTEXELEMENT9) * count);
+      sizeof(D3DVERTEXELEMENT9) * m_elements.size());
+
+    pElement[m_elements.size()] = D3DDECL_END();
 
     return D3D_OK;
   }


### PR DESCRIPTION
> The number of elements, pNumElements, includes the D3DDECL_END macro, which ends the declaration. So the element count is actually one higher than the number of valid vertex elements.

https://docs.microsoft.com/en-us/windows/desktop/api/d3d9helper/nf-d3d9helper-idirect3dvertexdeclaration9-getdeclaration

Fixes crashes in Risen