### PR TITLE
Various CPU optimizations

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4868,15 +4868,15 @@ namespace dxvk {
   void D3D9DeviceEx::UpdateFixedFunctionVS() {
     // Spec Constants...
     if (m_state.vertexDecl != nullptr) {
-      const bool hasColor = m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor);
+      const bool hasColor     = m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor);
       const bool hasPositionT = m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);
       EmitCs([
-        cHasColor = hasColor,
-          cHasPositionT = hasPositionT
+        cHasColor     = hasColor,
+        cHasPositionT = hasPositionT
       ](DxvkContext* ctx) {
-          ctx->setSpecConstant(D3D9SpecConstantId::FFHasColor, cHasColor);
+          ctx->setSpecConstant(D3D9SpecConstantId::FFHasColor,     cHasColor);
           ctx->setSpecConstant(D3D9SpecConstantId::FFHasPositionT, cHasPositionT);
-        });
+      });
     }
 
     // Transforms...

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4877,7 +4877,7 @@ namespace dxvk {
         cHasColor     = hasColor,
         cHasPositionT = hasPositionT
       ](DxvkContext* ctx) {
-          ctx->setSpecConstant(D3D9SpecConstantId::FFHasColor,     cHasColor);
+        ctx->setSpecConstant(D3D9SpecConstantId::FFHasColor,     cHasColor);
           ctx->setSpecConstant(D3D9SpecConstantId::FFHasPositionT, cHasPositionT);
       });
     }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2049,6 +2049,7 @@ namespace dxvk {
     changePrivate(m_state.vertexDecl, decl);
 
     m_flags.set(D3D9DeviceFlag::DirtyInputLayout);
+    m_flags.set(D3D9DeviceFlag::DirtyFFDeclConstants);
 
     return D3D_OK;
   }
@@ -4867,7 +4868,9 @@ namespace dxvk {
 
   void D3D9DeviceEx::UpdateFixedFunctionVS() {
     // Spec Constants...
-    if (m_state.vertexDecl != nullptr) {
+    if (m_flags.test(D3D9DeviceFlag::DirtyFFDeclConstants) && m_state.vertexDecl != nullptr) {
+      m_flags.clr(D3D9DeviceFlag::DirtyFFDeclConstants);
+
       const bool hasColor     = m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor);
       const bool hasPositionT = m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);
       EmitCs([

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4878,7 +4878,7 @@ namespace dxvk {
         cHasPositionT = hasPositionT
       ](DxvkContext* ctx) {
         ctx->setSpecConstant(D3D9SpecConstantId::FFHasColor,     cHasColor);
-          ctx->setSpecConstant(D3D9SpecConstantId::FFHasPositionT, cHasPositionT);
+        ctx->setSpecConstant(D3D9SpecConstantId::FFHasPositionT, cHasPositionT);
       });
     }
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4558,20 +4558,8 @@ namespace dxvk {
 
     if (likely(UseProgrammableVS()))
       UploadConstants<DxsoProgramTypes::VertexShader>();
-    else {
-      if (m_state.vertexDecl != nullptr) {
-        const bool hasColor     = m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor);
-        const bool hasPositionT = m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);
-        EmitCs([
-          cHasColor     = hasColor,
-          cHasPositionT = hasPositionT
-        ](DxvkContext* ctx) {
-          ctx->setSpecConstant(D3D9SpecConstantId::FFHasColor,     cHasColor);
-          ctx->setSpecConstant(D3D9SpecConstantId::FFHasPositionT, cHasPositionT);
-        });
-      }
+    else
       UpdateFixedFunctionVS();
-    }
 
     if (likely(UseProgrammablePS()))
       UploadConstants<DxsoProgramTypes::PixelShader>();
@@ -4878,6 +4866,20 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::UpdateFixedFunctionVS() {
+    // Spec Constants...
+    if (m_state.vertexDecl != nullptr) {
+      const bool hasColor = m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor);
+      const bool hasPositionT = m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);
+      EmitCs([
+        cHasColor = hasColor,
+          cHasPositionT = hasPositionT
+      ](DxvkContext* ctx) {
+          ctx->setSpecConstant(D3D9SpecConstantId::FFHasColor, cHasColor);
+          ctx->setSpecConstant(D3D9SpecConstantId::FFHasPositionT, cHasPositionT);
+        });
+    }
+
+    // Transforms...
     DxvkBufferSliceHandle slice = m_vsFixedFunction->allocSlice();
 
     EmitCs([

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4880,19 +4880,23 @@ namespace dxvk {
     }
 
     // Transforms...
-    DxvkBufferSliceHandle slice = m_vsFixedFunction->allocSlice();
+    if (m_flags.test(D3D9DeviceFlag::DirtyTransforms)) {
+      m_flags.clr(D3D9DeviceFlag::DirtyTransforms);
 
-    EmitCs([
-      cBuffer = m_vsFixedFunction,
-      cSlice  = slice
-    ] (DxvkContext* ctx) {
-      ctx->invalidateBuffer(cBuffer, cSlice);
-    });
+      DxvkBufferSliceHandle slice = m_vsFixedFunction->allocSlice();
 
-    D3D9FixedFunctionVS* data = reinterpret_cast<D3D9FixedFunctionVS*>(slice.mapPtr);
-    data->World      = m_state.transforms[GetTransformIndex(D3DTS_WORLD)];
-    data->View       = m_state.transforms[GetTransformIndex(D3DTS_VIEW)];
-    data->Projection = m_state.transforms[GetTransformIndex(D3DTS_PROJECTION)];
+      EmitCs([
+        cBuffer = m_vsFixedFunction,
+        cSlice  = slice
+      ] (DxvkContext* ctx) {
+        ctx->invalidateBuffer(cBuffer, cSlice);
+      });
+
+      D3D9FixedFunctionVS* data = reinterpret_cast<D3D9FixedFunctionVS*>(slice.mapPtr);
+      data->World      = m_state.transforms[GetTransformIndex(D3DTS_WORLD)];
+      data->View       = m_state.transforms[GetTransformIndex(D3DTS_VIEW)];
+      data->Projection = m_state.transforms[GetTransformIndex(D3DTS_PROJECTION)];
+    }
   }
 
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2293,11 +2293,19 @@ namespace dxvk {
         Stride);
 
     auto& vbo = m_state.vertexBuffers[StreamNumber];
-    changePrivate(vbo.vertexBuffer, buffer);
+    bool needsUpdate = vbo.vertexBuffer != buffer;
+
+    if (needsUpdate)
+      changePrivate(vbo.vertexBuffer, buffer);
+
+    needsUpdate |= vbo.offset != OffsetInBytes
+                || vbo.stride != Stride;
+
     vbo.offset = OffsetInBytes;
     vbo.stride = Stride;
 
-    BindVertexBuffer(StreamNumber, buffer, OffsetInBytes, Stride);
+    if (needsUpdate)
+      BindVertexBuffer(StreamNumber, buffer, OffsetInBytes, Stride);
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3871,10 +3871,10 @@ namespace dxvk {
     info.size = caps::MaxClipPlanes * sizeof(D3D9ClipPlane);
     m_vsClipPlanes = m_dxvkDevice->createBuffer(info, memoryFlags);
 
-    info.size = caps::MaxClipPlanes * sizeof(D3D9FixedFunctionVS);
+    info.size = sizeof(D3D9FixedFunctionVS);
     m_vsFixedFunction = m_dxvkDevice->createBuffer(info, memoryFlags);
 
-    info.size = caps::MaxClipPlanes * sizeof(D3D9FixedFunctionPS);
+    info.size = sizeof(D3D9FixedFunctionPS);
     m_psFixedFunction = m_dxvkDevice->createBuffer(info, memoryFlags);
 
     auto BindConstantBuffer = [this](

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -56,9 +56,8 @@ namespace dxvk {
   using D3D9DeviceFlags = Flags<D3D9DeviceFlag>;
 
   struct D3D9DrawInfo {
-    DxvkInputAssemblyState iaState;
-    uint32_t               vertexCount;
-    uint32_t               instanceCount;
+    uint32_t vertexCount;
+    uint32_t instanceCount;
   };
 
   struct D3D9SamplerPair {
@@ -1008,6 +1007,10 @@ namespace dxvk {
     void UpdateFixedFunctionVS();
 
     void UpdateFixedFunctionPS();
+
+    void ApplyPrimitiveType(
+      DxvkContext*      pContext,
+      D3DPRIMITIVETYPE  PrimType);
 
     bool UseProgrammableVS();
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -733,11 +733,6 @@ namespace dxvk {
     
     template <DxsoProgramType ShaderStage>
     void UploadConstants();
-
-    inline void UpdateConstants() {
-      UploadConstants<DxsoProgramTypes::VertexShader>();
-      UploadConstants<DxsoProgramTypes::PixelShader>();
-    }
     
     void UpdateClipPlanes();
     
@@ -870,6 +865,11 @@ namespace dxvk {
 
     Rc<DxvkBuffer>                  m_vsClipPlanes;
 
+    Rc<DxvkBuffer>                  m_vsFixedFunction;
+    Rc<DxvkBuffer>                  m_psFixedFunction;
+
+    Rc<DxvkShader>                  m_ffShaders[DxsoProgramTypes::Count];
+
     Rc<DxvkBuffer>                  m_upBuffer;
 
     const D3D9VkFormatTable         m_d3d9Formats;
@@ -997,6 +997,16 @@ namespace dxvk {
 
       return D3D_OK;
     }
+
+    void CreateFixedFunctionShaders();
+
+    void UpdateFixedFunctionVS();
+
+    void UpdateFixedFunctionPS();
+
+    bool UseProgrammableVS();
+
+    bool UseProgrammablePS();
 
   };
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -46,6 +46,7 @@ namespace dxvk {
     DirtyViewportScissor,
     DirtyMultiSampleState,
     DirtyTransforms,
+    DirtyFFDeclConstants,
     UpDirtiedVertices,
     UpDirtiedIndices,
     ValidSampleMask,

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -753,7 +753,10 @@ namespace dxvk {
 
     D3D9DrawInfo GenerateDrawInfo(
       D3DPRIMITIVETYPE PrimitiveType,
-      UINT             PrimitiveCount);
+      UINT             PrimitiveCount,
+      UINT             InstanceCount);
+    
+    uint32_t GetInstanceCount() const;
 
     void PrepareDraw(bool up = false);
 
@@ -896,7 +899,8 @@ namespace dxvk {
       DWORD,
       Com<D3D9VertexDecl>> m_fvfTable;
 
-    uint32_t                        m_streamUsageMask = 0;
+    D3D9InputAssemblyState          m_iaState;
+
     uint32_t                        m_instancedData   = 0;
 
     std::atomic<int64_t>            m_availableMemory = 0;
@@ -917,7 +921,7 @@ namespace dxvk {
       const DxsoModuleInfo*       pModuleInfo);
 
     template<typename T>
-    const D3D9CommonShader* GetCommonShader(T* pShader) const {
+    static const D3D9CommonShader* GetCommonShader(T* pShader) {
       return pShader != nullptr ? pShader->GetCommonShader() : nullptr;
     }
 

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -7,6 +7,8 @@ namespace dxvk {
   enum D3D9SpecConstantId : uint32_t {
     AlphaTestEnable = 0,
     AlphaCompareOp  = 1,
+    FFHasPositionT  = 2,
+    FFHasColor      = 3,
   };
 
 }

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -38,6 +38,16 @@ namespace dxvk {
     AlphaRef = 0,
     Count    = 1
   };
+
+  struct D3D9FixedFunctionVS {
+    Matrix4 World;
+    Matrix4 View;
+    Matrix4 Projection;
+  };
+
+  struct D3D9FixedFunctionPS {
+
+  };
   
   struct D3D9VBO {
     D3D9VertexBuffer* vertexBuffer = nullptr;

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -199,6 +199,7 @@ namespace dxvk {
 
 
   struct D3D9InputAssemblyState {
+    D3DPRIMITIVETYPE primitiveType = D3DPRIMITIVETYPE(0);
     uint32_t streamsInstanced = 0;
     uint32_t streamsUsed      = 0;
   };

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -197,4 +197,10 @@ namespace dxvk {
     
   };
 
+
+  struct D3D9InputAssemblyState {
+    uint32_t streamsInstanced = 0;
+    uint32_t streamsUsed      = 0;
+  };
+
 }

--- a/src/d3d9/d3d9_vertex_declaration.cpp
+++ b/src/d3d9/d3d9_vertex_declaration.cpp
@@ -11,6 +11,7 @@ namespace dxvk {
           DWORD              FVF)
     : D3D9VertexDeclBase(pDevice) {
     this->SetFVF(FVF);
+    this->Classify();
   }
 
 
@@ -22,6 +23,7 @@ namespace dxvk {
     , m_elements        ( DeclCount )
     , m_fvf             ( 0 ) {
     std::copy(pVertexElements, pVertexElements + DeclCount, m_elements.begin());
+    this->Classify();
   }
 
 
@@ -201,6 +203,15 @@ namespace dxvk {
 
     m_elements.resize(elemCount);
     std::copy(elements.begin(), elements.begin() + elemCount, m_elements.data());
+  }
+
+  void D3D9VertexDecl::Classify() {
+    for (const auto& element : m_elements) {
+      if (element.Usage == D3DDECLUSAGE_COLOR)
+        m_flags.set(D3D9VertexDeclFlag::HasColor);
+      else if (element.Usage == D3DDECLUSAGE_POSITIONT)
+        m_flags.set(D3D9VertexDeclFlag::HasPositionT);
+    }
   }
 
 }

--- a/src/d3d9/d3d9_vertex_declaration.h
+++ b/src/d3d9/d3d9_vertex_declaration.h
@@ -6,6 +6,12 @@
 
 namespace dxvk {
 
+  enum D3D9VertexDeclFlag {
+    HasColor,
+    HasPositionT
+  };
+  using D3D9VertexDeclFlags = Flags<D3D9VertexDeclFlag>;
+
   using D3D9VertexDeclBase = D3D9DeviceChild<IDirect3DVertexDeclaration9>;
   class D3D9VertexDecl final : public D3D9VertexDeclBase {
 
@@ -38,7 +44,15 @@ namespace dxvk {
       return m_elements;
     }
 
+    bool TestFlag(D3D9VertexDeclFlag flag) const {
+      return m_flags.test(flag);
+    }
+
   private:
+
+    void Classify();
+
+    D3D9VertexDeclFlags            m_flags;
 
     std::vector<D3DVERTEXELEMENT9> m_elements;
 

--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -1,6 +1,9 @@
 d3d9_res = wrc_generator.process('version.rc')
 
 d3d9_shaders = files([
+  'shaders/d3d9_fixed_function_frag.frag',
+  'shaders/d3d9_fixed_function_vert.vert',
+
   '../dxgi/shaders/dxgi_presenter_frag.frag',
   '../dxgi/shaders/dxgi_presenter_vert.vert',
 ])

--- a/src/d3d9/shaders/d3d9_fixed_function_frag.frag
+++ b/src/d3d9/shaders/d3d9_fixed_function_frag.frag
@@ -1,0 +1,72 @@
+#version 450
+
+// Fixed Frog Pipeline
+
+layout (constant_id = 13) const bool s_texture_bound = true;
+layout (binding = 13) uniform sampler2D s_texture;
+
+layout (constant_id = 1249) const bool alpha_test = false;
+layout (constant_id = 1250) const uint alpha_func = 7u;
+
+layout (push_constant) uniform render_state_t {
+  float alpha_ref;
+} render_state;
+
+layout (location = 0) in vec4 in_TEXCOORD[8];
+layout (location = 8) in vec4 in_COLOR;
+
+layout (location = 0) out vec4 o_color;
+
+void ps_main() {
+  if (s_texture_bound)
+    o_color *= texture(s_texture, in_TEXCOORD[0].xy);
+}
+
+void main() {
+  o_color = in_COLOR;
+
+  ps_main();
+
+  if (alpha_test) {
+    bool keep;
+    switch (alpha_func)
+    {
+      case 0u: {
+        keep = false;
+        break;
+      }
+      case 1u: {
+        keep = o_color.a < render_state.alpha_ref;
+        break;
+      }
+      case 2u: {
+        keep = o_color.a == render_state.alpha_ref;
+        break;
+      }
+      case 3u: {
+        keep = o_color.a <= render_state.alpha_ref;
+        break;
+      }
+      case 4u: {
+        keep = o_color.a > render_state.alpha_ref;
+        break;
+      }
+      case 5u: {
+        keep = o_color.a != render_state.alpha_ref;
+        break;
+      }
+      case 6u: {
+        keep = o_color.a >= render_state.alpha_ref;
+        break;
+      }
+      case 7u:
+      default: {
+        keep = true;
+        break;
+      }
+    }
+    if (!keep)
+      discard;
+  }
+
+}

--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -1,0 +1,36 @@
+#version 450
+
+// Fixed Frog Pipeline
+
+layout(binding = 2) uniform D3D9FixedFunctionVS {
+  layout(row_major) mat4 D3DTS_WORLD;
+  layout(row_major) mat4 D3DTS_VIEW;
+  layout(row_major) mat4 D3DTS_PROJECTION;
+};
+
+layout (constant_id = 1251) const bool ff_has_position_t = false;
+layout (constant_id = 1252) const bool ff_has_color = false;
+
+layout (location = 0) in vec4 in_POSITION;
+layout (location = 1) in vec4 in_TEXCOORD[8];
+layout (location = 9) in vec4 in_COLOR;
+
+layout (location = 0) out vec4 out_TEXCOORD[8];
+layout (location = 8) out vec4 out_COLOR;
+
+void main() {
+  gl_Position = vec4(in_POSITION.xyz, 1);
+
+  if (!ff_has_position_t) {
+    mat4 wvp = D3DTS_WORLD * D3DTS_VIEW * D3DTS_PROJECTION;
+    gl_Position = gl_Position * wvp;
+  }
+
+  for (uint i = 0; i < 8; i++)
+    out_TEXCOORD[i] = in_TEXCOORD[i];
+
+  if (ff_has_color)
+    out_COLOR = in_COLOR;
+  else
+    out_COLOR = vec4(1,1,1,1);
+}


### PR DESCRIPTION
This series should reduce CPU overhead a bit, especially in the following situations:

- When a vertex buffer is being rebound multiple times, redundant atomic operations are eliminated, and completely redundant vertex buffer binding operations are ignored. This optimization was taken from D3D11.
- Input layouts are now generated on the CS thread to take load off the main thread.
- The input assembly state is no longer set redundantly to take load off the CS thread.