### PR TITLE
Optimize shader constant updates

### DIFF
--- a/src/d3d9/d3d9_constant_set.h
+++ b/src/d3d9/d3d9_constant_set.h
@@ -2,6 +2,8 @@
 
 #include "d3d9_caps.h"
 
+#include "../dxso/dxso_isgn.h"
+
 #include "../util/util_math.h"
 #include "../util/util_vector.h"
 
@@ -25,10 +27,10 @@ namespace dxvk {
   };
 
   struct D3D9ConstantSets {
-    constexpr static uint32_t SetSize    = sizeof(D3D9ShaderConstants);
-    Rc<DxvkBuffer> buffer;
-    bool           dirty = true;
-    bool           shaderConstantCopies = false;
+    constexpr static uint32_t SetSize = sizeof(D3D9ShaderConstants);
+    Rc<DxvkBuffer>            buffer;
+    const DxsoShaderMetaInfo* meta  = nullptr;
+    bool                      dirty = true;
   };
 
 }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2149,11 +2149,14 @@ namespace dxvk {
     bool oldCopies = oldShader && oldShader->GetMeta().needsConstantCopies;
     bool newCopies = newShader && newShader->GetMeta().needsConstantCopies;
 
-    bool dirtyConstants = oldCopies || newCopies;
+    m_consts[DxsoProgramTypes::VertexShader].dirty |= oldCopies || newCopies || !oldShader;
+    m_consts[DxsoProgramTypes::VertexShader].meta  = newShader ? &newShader->GetMeta() : nullptr;
 
-    if (dirtyConstants) {
-      m_consts[DxsoProgramTypes::VertexShader].dirty = true;
-      m_consts[DxsoProgramTypes::VertexShader].shaderConstantCopies = newCopies;
+    if (newShader && oldShader) {
+      m_consts[DxsoProgramTypes::VertexShader].dirty
+        |= newShader->GetMeta().maxConstIndexF != oldShader->GetMeta().maxConstIndexF
+        || newShader->GetMeta().maxConstIndexI != oldShader->GetMeta().maxConstIndexI
+        || newShader->GetMeta().maxConstIndexB != oldShader->GetMeta().maxConstIndexB;
     }
 
     changePrivate(m_state.vertexShader, shader);
@@ -2460,11 +2463,14 @@ namespace dxvk {
     bool oldCopies = oldShader && oldShader->GetMeta().needsConstantCopies;
     bool newCopies = newShader && newShader->GetMeta().needsConstantCopies;
 
-    bool dirtyConstants = oldCopies || newCopies;
+    m_consts[DxsoProgramTypes::PixelShader].dirty |= oldCopies || newCopies || !oldShader;
+    m_consts[DxsoProgramTypes::PixelShader].meta  = newShader ? &newShader->GetMeta() : nullptr;
 
-    if (dirtyConstants) {
-      m_consts[DxsoProgramTypes::PixelShader].dirty = true;
-      m_consts[DxsoProgramTypes::PixelShader].shaderConstantCopies = newCopies;
+    if (newShader && oldShader) {
+      m_consts[DxsoProgramTypes::PixelShader].dirty
+        |= newShader->GetMeta().maxConstIndexF != oldShader->GetMeta().maxConstIndexF
+        || newShader->GetMeta().maxConstIndexI != oldShader->GetMeta().maxConstIndexI
+        || newShader->GetMeta().maxConstIndexB != oldShader->GetMeta().maxConstIndexB;
     }
 
     changePrivate(m_state.pixelShader, shader);
@@ -3916,9 +3922,10 @@ namespace dxvk {
 
     constSet.dirty = false;
 
-    const void* constantData = &m_state.consts[ShaderStage].hardware;
-
     DxvkBufferSliceHandle slice = constSet.buffer->allocSlice();
+
+    auto dstData = reinterpret_cast<D3D9ShaderConstants*>(slice.mapPtr);
+    auto srcData = &m_state.consts[ShaderStage];
 
     EmitCs([
       cBuffer = constSet.buffer,
@@ -3927,9 +3934,18 @@ namespace dxvk {
       ctx->invalidateBuffer(cBuffer, cSlice);
     });
 
-    std::memcpy(slice.mapPtr, constantData, D3D9ConstantSets::SetSize);
+    if (constSet.meta->usesRelativeIndexing) {
+      std::memcpy(dstData, srcData, D3D9ConstantSets::SetSize);
+    } else {
+      if (constSet.meta->maxConstIndexF)
+        std::memcpy(&dstData->hardware.fConsts[0], &srcData->hardware.fConsts[0], sizeof(Vector4) * constSet.meta->maxConstIndexF);
+      if (constSet.meta->maxConstIndexI)
+        std::memcpy(&dstData->hardware.iConsts[0], &srcData->hardware.iConsts[0], sizeof(Vector4) * constSet.meta->maxConstIndexI);
+      if (constSet.meta->maxConstIndexB)
+        dstData->hardware.boolBitfield = srcData->hardware.boolBitfield;
+    }
 
-    if (constSet.shaderConstantCopies) {
+    if (constSet.meta->needsConstantCopies) {
       Vector4* data =
         reinterpret_cast<Vector4*>(slice.mapPtr);
 

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -710,12 +710,26 @@ namespace dxvk {
 
     // Return def if we have one.
     if (relative == nullptr) {
-      if (type == DxsoRegisterType::Const && m_cFloat.at(reg.id.num).id != 0)
-        return m_cFloat.at(reg.id.num);
-      else if (type == DxsoRegisterType::ConstInt && m_cInt.at(reg.id.num).id != 0)
-        return m_cInt.at(reg.id.num);
-      else if (type == DxsoRegisterType::ConstBool && m_cBool.at(reg.id.num).id != 0){ // Const Bool
-        return m_cBool.at(reg.id.num);
+      switch (type) {
+        case DxsoRegisterType::Const:
+          m_meta.maxConstIndexF = std::max(m_meta.maxConstIndexF, reg.id.num + 1);
+          if (m_cFloat.at(reg.id.num).id != 0)
+            return m_cFloat.at(reg.id.num);
+          break;
+        
+        case DxsoRegisterType::ConstInt:
+          m_meta.maxConstIndexI = std::max(m_meta.maxConstIndexI, reg.id.num + 1);
+          if (m_cInt.at(reg.id.num).id != 0)
+            return m_cInt.at(reg.id.num);
+          break;
+        
+        case DxsoRegisterType::ConstBool:
+          m_meta.maxConstIndexB = std::max(m_meta.maxConstIndexB, reg.id.num + 1);
+          if (m_cBool.at(reg.id.num).id != 0) // Const Bool
+            return m_cBool.at(reg.id.num);
+          break;
+        
+        default:;
       }
     }
 

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -811,6 +811,7 @@ namespace dxvk {
       const DxsoBaseRegister* relative) {
     // Only float constants (+ io regs) may be indexed.
     if (relative != nullptr && reg.id.type == DxsoRegisterType::Const) {
+      m_meta.usesRelativeIndexing = true;
       if (m_moduleInfo.options.strictConstantCopies || m_cFloat.at(reg.id.num).id != 0)
         m_meta.needsConstantCopies = true;
     }

--- a/src/dxso/dxso_isgn.h
+++ b/src/dxso/dxso_isgn.h
@@ -32,6 +32,9 @@ namespace dxvk {
   struct DxsoShaderMetaInfo {
     bool needsConstantCopies = false;
     bool usesRelativeIndexing = false;
+    uint32_t maxConstIndexF = 0;
+    uint32_t maxConstIndexI = 0;
+    uint32_t maxConstIndexB = 0;
   };
 
 }

--- a/src/dxso/dxso_isgn.h
+++ b/src/dxso/dxso_isgn.h
@@ -31,6 +31,7 @@ namespace dxvk {
 
   struct DxsoShaderMetaInfo {
     bool needsConstantCopies = false;
+    bool usesRelativeIndexing = false;
   };
 
 }


### PR DESCRIPTION
Improves performance in Dragon Age Origins by ~10%.

This does **not** perform any sort of compaction just yet. Implementing that would require an analysis pass in the shader compiler that figures out whether relative indexing is used, which might be quite tricky to do.