### PR TITLE
[util] Disable readonly locking for Risen 2 & 3

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -168,6 +168,14 @@ namespace dxvk {
     { "Risen.exe", {{
       { "d3d9.allowLockFlagReadonly",       "False" },
     }} },
+    /* Risen 2                                    */
+    { "Risen2.exe", {{
+      { "d3d9.allowLockFlagReadonly",       "False" },
+    }} },
+    /* Risen 3                                    */
+    { "Risen3.exe", {{
+      { "d3d9.allowLockFlagReadonly",       "False" },
+    }} },
     /* Star Wars: The Force Unleashed 1 & 2       */
     { "SWTFU.exe", {{
       { "d3d9.hasHazards",                  "True" },


### PR DESCRIPTION
Risen 2 and 3 suffer from the same issue as Risen 1.