### PR TITLE
Properly initialize state block

### DIFF
--- a/src/d3d9/d3d9_stateblock.h
+++ b/src/d3d9/d3d9_stateblock.h
@@ -319,7 +319,7 @@ namespace dxvk {
 
     D3D9CapturableState* m_deviceState;
 
-    bool                 m_applying;
+    bool                 m_applying = false;
 
   };
 


### PR DESCRIPTION
Fixes the loading screen in Guild 2 when D9VK gets compiled with MSVC.

~~Might also fix the main menu with the constant opt branch.~~

Also fixes the main menu issues with the constant-opt branch according to Riesi.