### PR TITLE
[d3d9] Correct highest texture stage type

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1799,6 +1799,8 @@ namespace dxvk {
           DWORD                    Stage,
           D3DTEXTURESTAGESTATETYPE Type,
           DWORD*                   pValue) {
+    D3D9DeviceLock lock = LockDevice();
+
     if (unlikely(pValue == nullptr))
       return D3DERR_INVALIDCALL;
 
@@ -1807,7 +1809,7 @@ namespace dxvk {
     if (unlikely(Stage >= caps::TextureStageCount))
       return D3DERR_INVALIDCALL;
 
-    if (unlikely(Type >= D3DTSS_CONSTANT))
+    if (unlikely(Type >= TextureStageStateCount))
       return D3DERR_INVALIDCALL;
 
     *pValue = m_state.textureStages[Stage][Type];


### PR DESCRIPTION
Closes #203 

Fixes a crash in Torchlight. The game doesn't render correctly (probably because of unimplemented fixed function stuff) but at least it doesn't crash anymore.
