### PR TITLE
[d3d9] Properly check mip level for cube map surfaces

### DIFF
--- a/src/d3d9/d3d9_texture.cpp
+++ b/src/d3d9/d3d9_texture.cpp
@@ -206,6 +206,9 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D9TextureCube::GetCubeMapSurface(D3DCUBEMAP_FACES Face, UINT Level, IDirect3DSurface9** ppSurfaceLevel) {
     InitReturnPtr(ppSurfaceLevel);
 
+    if (Level >= m_texture.Desc()->MipLevels)
+      return D3DERR_INVALIDCALL;
+
     auto* surface = GetSubresource(
       m_texture.CalcSubresource(UINT(Face), Level));
 


### PR DESCRIPTION
Fixes #208
(Hopefully)

Just checking the subresource isn't sufficient because it would just return the first mip level of the next face.