### PR TITLE
[d3d9] Improve AllocUpBuffer behaviour to waste less memory

### DIFF
--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -71,6 +71,11 @@ namespace dxvk {
     Rc<DxvkSampler> depth;
   };
 
+  struct D3D9UPBufferSlice {
+    DxvkBufferSlice slice;
+    void*           mapPtr;
+  };
+
   class D3D9DeviceEx final : public ComObjectClamp<IDirect3DDevice9Ex> {
     constexpr static uint32_t DefaultFrameLatency = 3;
     constexpr static uint32_t MaxFrameLatency     = 20;
@@ -872,7 +877,7 @@ namespace dxvk {
     Rc<DxvkBuffer>                  m_vsFixedFunction;
     Rc<DxvkBuffer>                  m_psFixedFunction;
 
-    Rc<DxvkBuffer>                  m_upBuffer;
+    D3D9UPBufferSlice               m_upBuffer;
 
     const D3D9Options               m_d3d9Options;
     const DxsoOptions               m_dxsoOptions;
@@ -909,7 +914,7 @@ namespace dxvk {
     bool                            m_amdATOC         = false;
     bool                            m_nvATOC          = false;
 
-    void AllocUpBuffer(uint32_t size);
+    D3D9UPBufferSlice AllocUpBuffer(VkDeviceSize size);
 
     D3D9SwapChainEx* GetInternalSwapchain(UINT index);
 

--- a/src/dxvk/dxvk_buffer.h
+++ b/src/dxvk/dxvk_buffer.h
@@ -382,7 +382,7 @@ namespace dxvk {
      * \returns The sub slice object
      */
     DxvkBufferSlice subSlice(VkDeviceSize offset, VkDeviceSize length) const {
-      return DxvkBufferSlice(m_buffer, offset, length);
+      return DxvkBufferSlice(m_buffer, m_offset + offset, length);
     }
     
     /**


### PR DESCRIPTION
The previous implementation had one major issue: If a game calls `DrawPrimitiveUP` once with a large number of vertices and then submits many draw calls with a small vertex count, we'd allocate one large buffer slice on each draw call.

This new implementation copies all vertex and index data into one 4MB slice until it is full, resulting in a lower memory footprint. For more than 4MB of data, a temporary buffer is allocated, but this should hopefully never happen in practice.