### PR TITLE
[d3d9] Don't use DEVICE_LOCAL memory for shader constant buffers

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4027,8 +4027,7 @@ namespace dxvk {
     info.usage  = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     info.access = VK_ACCESS_UNIFORM_READ_BIT;
 
-    VkMemoryPropertyFlags memoryFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
-                                      | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
+    VkMemoryPropertyFlags memoryFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
                                       | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 
     info.stages = VK_PIPELINE_STAGE_VERTEX_SHADER_BIT;


### PR DESCRIPTION
While it is usually a good idea to use `DEVICE_LOCAL | HOST_VISIBLE` memory for uniform buffers, it doesn't really seem to work all that well in D3D9 workloads and heavily tanks CPU-bound performance for some reason.

This improves CPU-bound performance in The Witcher 2 by ~25%; GPU-bound perf takes a negligible hit (~1% or so, probably within error margins).

I'm not entirely sure *why* the performance hit is this dramatic, but one reason might be that for shaders with dynamic indexing, we have to always upload the entire buffer, which usually leads to a **lot** of data being written but never read.

This won't have any effect at all on systems with Nvidia GPUs since they don't expose host-visible device memory.