### PR TITLE
[d3d9] Properly wait for texture mapping buffers

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3705,11 +3705,11 @@ namespace dxvk {
       // that cannot get affected by GPU, therefore readonly is A-OK for NOT waiting.
       const bool noOverwrite  = Flags & D3DLOCK_NOOVERWRITE;
       const bool readOnly     = Flags & D3DLOCK_READONLY;
-      const bool gpuImmutable = (readOnly && managed) || scratch || (systemmem && !modified);
+      const bool skipWait = (readOnly && managed) || scratch || (readOnly && systemmem && !modified);
 
       if (alloced)
         std::memset(physSlice.mapPtr, 0, physSlice.length);
-      else if (!noOverwrite && !gpuImmutable) {
+      else if (!noOverwrite && !skipWait) {
         pResource->UnmarkSystemMemGPUModified();
         if (!WaitForResource(mappedBuffer, Flags))
           return D3DERR_WASSTILLDRAWING;


### PR DESCRIPTION
Fixes #247 

You can use sysmem textures as the source for copy operations and we should avoid rewriting the texture data while a copy is happening.