### PR TITLE
[dxvk] Improve DxvkImageView::handle()

### DIFF
--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -309,9 +309,9 @@ namespace dxvk {
      * \returns The image view handle
      */
     VkImageView handle(VkImageViewType viewType) const {
-      return viewType != VK_IMAGE_VIEW_TYPE_MAX_ENUM
-        ? m_views[viewType]
-        : m_views[m_info.type];
+      if (unlikely(viewType == VK_IMAGE_VIEW_TYPE_MAX_ENUM))
+        viewType = m_info.type;
+      return m_views[viewType];
     }
     
     /**


### PR DESCRIPTION
Should fix a silly compiler warning and improves code gen, which
is important since this is *the* most frequently called function
in the backend.