### PR TITLE
[d3d9] Check texture usage in SetRT and SetDS

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1075,6 +1075,9 @@ namespace dxvk {
 
     D3D9Surface* rt = static_cast<D3D9Surface*>(pRenderTarget);
 
+    if (unlikely(rt && !(rt->GetCommonTexture()->Desc()->Usage & D3DUSAGE_RENDERTARGET)))
+      return D3DERR_INVALIDCALL;
+
     if (m_state.renderTargets[RenderTargetIndex] == rt)
       return D3D_OK;
 
@@ -1144,6 +1147,9 @@ namespace dxvk {
     D3D9DeviceLock lock = LockDevice();
 
     D3D9Surface* ds = static_cast<D3D9Surface*>(pNewZStencil);
+
+    if (unlikely(ds && !(ds->GetCommonTexture()->Desc()->Usage & D3DUSAGE_DEPTHSTENCIL)))
+      return D3DERR_INVALIDCALL;
 
     if (m_state.depthStencil == ds)
       return D3D_OK;


### PR DESCRIPTION
This hasn't caused any issues yet but there are probably games out there that will break if we don't check it correctly.