### PR TITLE
[d3d9] Optimize UndirtySamplers

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4717,11 +4717,9 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::UndirtySamplers() {
-    for (uint32_t i = 0; i < 21; i++) {
-      if (m_dirtySamplerStates & (1u << i))
-        BindSampler(i);
-    }
-
+    for (uint32_t dirty = m_dirtySamplerStates; dirty; dirty &= dirty - 1)
+      BindSampler(bit::tzcnt(dirty));
+    
     m_dirtySamplerStates = 0;
   }
 
@@ -4762,7 +4760,8 @@ namespace dxvk {
     if (m_flags.test(D3D9DeviceFlag::DirtyViewportScissor))
       BindViewportAndScissor();
 
-    UndirtySamplers();
+    if (m_dirtySamplerStates)
+      UndirtySamplers();
 
     if (m_flags.test(D3D9DeviceFlag::DirtyBlendState))
       BindBlendState();


### PR DESCRIPTION
Basically, instead of walking over all 21 samplers every time
and checking whether they are dirty, just iterate over the
dirty bits.