### PR TITLE
[d3d9] Implement NV depth bounds hack format

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -131,6 +131,9 @@ namespace dxvk {
     if (CheckFormat == D3D9Format::ATOC && surface)
       return D3D_OK;
 
+    if (CheckFormat == D3D9Format::NVDB && surface)
+      return D3D_OK;
+
     // I really don't want to support this...
     if (dmap)
       return D3DERR_NOTAVAILABLE;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1598,12 +1598,13 @@ namespace dxvk {
 
     if (likely(changed)) {
       const bool oldATOC = IsAlphaToCoverageEnabled();
+      const bool oldNVDB = states[D3DRS_ADAPTIVETESS_X] == uint32_t(D3D9Format::NVDB);
 
       // AMD's driver hack for ATOC and RESZ
       if (unlikely(State == D3DRS_POINTSIZE)) {
         // ATOC
-        constexpr uint32_t AlphaToCoverageEnable  = MAKEFOURCC('A', '2', 'M', '1');
-        constexpr uint32_t AlphaToCoverageDisable = MAKEFOURCC('A', '2', 'M', '0');
+        constexpr uint32_t AlphaToCoverageEnable  = uint32_t(D3D9Format::A2M1);
+        constexpr uint32_t AlphaToCoverageDisable = uint32_t(D3D9Format::A2M0);
 
         if (Value == AlphaToCoverageEnable
          || Value == AlphaToCoverageDisable) {
@@ -1627,7 +1628,7 @@ namespace dxvk {
 
       // NV's driver hack for ATOC.
       if (unlikely(State == D3DRS_ADAPTIVETESS_Y)) {
-        constexpr uint32_t AlphaToCoverageEnable  = MAKEFOURCC('A', 'T', 'O', 'C');
+        constexpr uint32_t AlphaToCoverageEnable  = uint32_t(D3D9Format::ATOC);
         constexpr uint32_t AlphaToCoverageDisable = 0;
 
         if (Value == AlphaToCoverageEnable
@@ -1742,6 +1743,14 @@ namespace dxvk {
         case D3DRS_AMBIENT:
           m_flags.set(D3D9DeviceFlag::DirtyFFVertexData);
           break;
+
+        case D3DRS_ADAPTIVETESS_X:
+        case D3DRS_ADAPTIVETESS_Z:
+        case D3DRS_ADAPTIVETESS_W:
+          if (states[D3DRS_ADAPTIVETESS_X] == uint32_t(D3D9Format::NVDB) || oldNVDB) {
+            m_flags.set(D3D9DeviceFlag::DirtyDepthBounds);
+            break;
+          }
 
         default:
           static bool s_errorShown[256];
@@ -5050,6 +5059,21 @@ namespace dxvk {
         data->Stages[i].BumpEnvLScale    = bit::cast<float>(m_state.textureStages[i][D3DTSS_BUMPENVLSCALE]);
         data->Stages[i].BumpEnvLOffset   = bit::cast<float>(m_state.textureStages[i][D3DTSS_BUMPENVLOFFSET]);
       }
+    }
+
+    if (m_flags.test(D3D9DeviceFlag::DirtyDepthBounds)) {
+      m_flags.clr(D3D9DeviceFlag::DirtyDepthBounds);
+
+      DxvkDepthBounds db;
+      db.enableDepthBounds  = (m_state.renderStates[D3DRS_ADAPTIVETESS_X] == uint32_t(D3D9Format::NVDB));
+      db.minDepthBounds     = bit::cast<float>(m_state.renderStates[D3DRS_ADAPTIVETESS_Z]);
+      db.maxDepthBounds     = bit::cast<float>(m_state.renderStates[D3DRS_ADAPTIVETESS_W]);
+
+      EmitCs([
+        cDepthBounds = db
+      ] (DxvkContext* ctx) {
+        ctx->setDepthBounds(cDepthBounds);
+      });
     }
   }
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -58,7 +58,8 @@ namespace dxvk {
     DirtySharedPixelShaderData,
     UpDirtiedVertices,
     UpDirtiedIndices,
-    ValidSampleMask
+    ValidSampleMask,
+    DirtyDepthBounds
   };
 
   using D3D9DeviceFlags = Flags<D3D9DeviceFlag>;

--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -352,7 +352,7 @@ namespace dxvk {
 
       case D3D9Format::GET1: return {}; // Unsupported
 
-      case D3D9Format::NVDB: return {}; // Unsupported
+      case D3D9Format::NVDB: return {}; // Driver hack, handled elsewhere
 
       case D3D9Format::A2M1: return {}; // Unsupported
 


### PR DESCRIPTION
This and not advertising support for `DF24` (which D9VK doesn't support properly anyway) fixes the shadows in Dead Space (#268) as it makes the game use the Nvidia rendering path that doesn't try to render it's shadow maps with a 1x1 render target attached.

The game also uses depth bias for shadow rendering so even once thats fixed shadows are probably not gonna look correct.