### PR TITLE
Check bytecode type when creating shaders

### DIFF
--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -82,6 +82,10 @@ namespace dxvk {
       reinterpret_cast<const char*>(pShaderBytecode));
 
     DxsoModule module(reader);
+
+    if (module.info().shaderStage() != ShaderStage)
+      throw DxvkError("GetShaderModule: Bytecode does not match shader stage");
+
     DxsoAnalysisInfo info = module.analyze();
 
     Sha1Hash hash = Sha1Hash::compute(

--- a/src/dxso/dxso_common.h
+++ b/src/dxso/dxso_common.h
@@ -47,7 +47,7 @@ namespace dxvk {
      *
      * The \c VkShaderStageFlagBits constant
      * that corresponds to the program type.
-     * \returns Vulkan shaer stage
+     * \returns Vulkan shader stage
      */
     VkShaderStageFlagBits shaderStage() const;
 


### PR DESCRIPTION
Witcher 2 tries to create vertex shaders with pixel shader bytecode. D3D9 and WineD3D both fail with INVALID_CALL. D9VK currently allows that and returns D3D_OK.

This PR fixes that.