### PR TITLE
Disable the DF24 format for Dead Space

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -148,6 +148,10 @@ namespace dxvk {
     if (RType == D3DRTYPE_VERTEXBUFFER || RType == D3DRTYPE_INDEXBUFFER)
       return D3D_OK;
 
+    auto& options = m_parent->GetOptions();
+    if ((CheckFormat == D3D9Format::DF16 || CheckFormat == D3D9Format::DF24) && !options.supportDFFormats)
+      return D3DERR_NOTAVAILABLE;
+
     // Let's actually ask Vulkan now that we got some quirks out the way!
 
     return CheckDeviceVkFormat(mapping.FormatColor, Usage, RType);

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -46,6 +46,7 @@ namespace dxvk {
     this->hasHazards            = config.getOption<bool>   ("d3d9.hasHazards",           false);
     this->samplerAnisotropy     = config.getOption<int32_t>("d3d9.samplerAnisotropy", -1);
     this->maxAvailableMemory    = config.getOption<uint32_t>("d3d9.maxAvailableMemory", UINT32_MAX);
+    this->supportDFFormats      = config.getOption<bool>("d3d9.supportDFFormats", true);
 
     this->d3d9FloatEmulation    = true; // <-- Future Extension?
 

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -74,6 +74,9 @@ namespace dxvk {
 
     /// D3D9 Floating Point Emulation (anything * 0 = 0)
     bool d3d9FloatEmulation;
+
+    /// Support the DF16 & DF24 texture format
+    bool supportDFFormats;
   };
 
 }

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -213,6 +213,11 @@ namespace dxvk {
     { R"(\\Sims2.*\.exe$)", {{
       { "d3d9.customVendorId",              "10de" },
     }} },
+    /* Dead Space uses the a NULL render target instead
+       of a 1x1 one if DF24 is NOT supported      */
+    { R"(\\Dead Space\.exe$)", {{
+      { "d3d9.supportDFFormats",                 "False" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes #268 

We've talked about this on Discord. I think this is the lesser evil compared to adding a hack to ignore 1x1 RTs.


