### PR TITLE
[d3d9] Don't initialize result pointer to nullptr in Create*Shader

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2461,8 +2461,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::CreateVertexShader(
     const DWORD*                   pFunction,
           IDirect3DVertexShader9** ppShader) {
-    InitReturnPtr(ppShader);
-
     if (unlikely(ppShader == nullptr))
       return D3DERR_INVALIDCALL;
 
@@ -2787,8 +2785,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::CreatePixelShader(
     const DWORD*                  pFunction,
           IDirect3DPixelShader9** ppShader) {
-    InitReturnPtr(ppShader);
-
     if (unlikely(ppShader == nullptr))
       return D3DERR_INVALIDCALL;
 


### PR DESCRIPTION
This makes Witcher 2 work again, which only renders the UI as of 696d189e2b.

What's most likely happening here is that the game calls CreatePixelShader and CreateVertexShader with the same result pointer, ignoring type safety, and uses the result of whichever call succeeds.

Note that this might not be 100% correct behaviour, and we should probably do some testing on what native d3d9 does under which circumstances and also check other Create* methods.