### PR TITLE
[dxso] Implement constant range check for relative indexing

### DIFF
--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -866,6 +866,21 @@ namespace dxvk {
         m_cBuffer, indices.size(), indices.data());
 
       result.id = m_module.opLoad(typeId, ptrId);
+
+      if (relative) {
+        uint32_t constCount = m_module.constu32(getFloatConstantCount());
+
+        // Expand condition to bvec4 since the result has four components
+        uint32_t cond = m_module.opULessThan(m_module.defBoolType(), relativeIdx, constCount);
+        std::array<uint32_t, 4> condIds = { cond, cond, cond, cond };
+
+        cond = m_module.opCompositeConstruct(
+          m_module.defVectorType(m_module.defBoolType(), 4),
+          condIds.size(), condIds.data());
+
+        result.id = m_module.opSelect(typeId, cond, result.id,
+          m_module.constvec4f32(0.0f, 0.0f, 0.0f, 0.0f));
+      }
     } else {
       uint32_t typeId = getScalarTypeId(DxsoScalarType::Uint32);
 

--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -437,8 +437,7 @@ namespace dxvk {
             spv::StorageClass storageClass = spv::StorageClassPrivate,
             spv::BuiltIn      builtIn      = spv::BuiltInMax);
 
-    DxsoRegisterPointer emitConstantPtr(
-            DxsoRegisterType  type,
+    DxsoRegisterValue emitLoadConstant(
       const DxsoBaseRegister& reg,
       const DxsoBaseRegister* relative);
 

--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -281,17 +281,9 @@ namespace dxvk {
 
     ////////////////////////////////////////
     // Constant buffer deffed mappings
-    std::array<
-      DxsoRegisterPointer,
-      caps::MaxFloatConstantsSoftware> m_cFloat;
-
-    std::array<
-      DxsoRegisterPointer,
-      caps::MaxOtherConstantsSoftware> m_cInt;
-
-    std::array<
-      DxsoRegisterPointer,
-      caps::MaxOtherConstantsSoftware> m_cBool;
+    std::array<uint32_t, caps::MaxFloatConstantsSoftware> m_cFloat;
+    std::array<uint32_t, caps::MaxOtherConstantsSoftware> m_cInt;
+    std::array<uint32_t, caps::MaxOtherConstantsSoftware> m_cBool;
 
     //////////////////////
     // Loop counter


### PR DESCRIPTION
This series refactors constant loading to not rely on `getOperandPtr`, similar to what has already been done for D3D11, and implements range checking on top of that. This should hopefully fix a number of issues related to out-of-bounds constant access on Nvidia GPUs.