### PR TITLE
[d3d9] Remove unneeded include

### DIFF
--- a/src/d3d9/d3d9_main.cpp
+++ b/src/d3d9/d3d9_main.cpp
@@ -1,5 +1,3 @@
-#include "../dxgi/dxgi_include.h"
-
 #include "../dxvk/dxvk_instance.h"
 
 #include "d3d9_interface.h"


### PR DESCRIPTION
Everything defined in d3d9_include.h
This should silence annoying warning during compilation.