### PR TITLE
[d3d9] Sync DLLEXPORT definition with DXVK

### DIFF
--- a/src/d3d9/d3d9_include.h
+++ b/src/d3d9/d3d9_include.h
@@ -11,7 +11,9 @@
 #include <d3d9.h>
 
 //for some reason we need to specify __declspec(dllexport) for MinGW
-#if defined(_MSC_VER) || defined(__WINE__)
+#if defined(__WINE__)
+#define DLLEXPORT __attribute__((visibility("default")))
+#elif defined(_MSC_VER)
 #define DLLEXPORT
 #else
 #define DLLEXPORT __declspec(dllexport)


### PR DESCRIPTION
Required for -fvisibility=hidden compiler flag (winelib compilation).