### PR TITLE
[util] Report 2GB vram max for The Sims 2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -212,7 +212,7 @@ namespace dxvk {
     /* The Sims 2                                 */
     { R"(\\Sims2.*\.exe$)", {{
       { "d3d9.customVendorId",              "10de" },
-      { "d3d9.maxAvailableMemory",     "3758096384" },
+      { "d3d9.maxAvailableMemory",          "2147483648" },
     }} },
     /* Dead Space uses the a NULL render target instead
        of a 1x1 one if DF24 is NOT supported      */


### PR DESCRIPTION
The current default value is definitely too high. I am able to reproduce a crash by simply trying to edit a community lot after entering Belladonna Cove on my RTX 2080 on Windows 10. Setting a lower value fixes the crashes and allows the game to be playable. Also, a high value prevents higher resolutions from loading to the neighborhood screen for some reason. 

Lower values than 2GB can definitely be used as well. The Sims 2 was developed in an era where high-end graphics cards topped out around 768MB. If there are further reports of crashes, advise future users to try lowering this value in `dxvk.conf` even more as a troubleshooting step. 

I don't think users will be clamoring to keep this value high though. Users who are looking to push graphical limits/fantasies in their Sims should look to later, more stable, more capable, and more pretty Sims games to fulfill them 😄.