### PR TITLE
[util] Disable read only locking for Burnout Paradise

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -219,6 +219,10 @@ namespace dxvk {
     { R"(\\Dead Space\.exe$)", {{
       { "d3d9.supportDFFormats",                 "False" },
     }} },
+    /* Burnout Paradise                           */
+    { R"(\\BurnoutParadise\.exe$)", {{
+      { "d3d9.allowLockFlagReadonly",       "False" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Maybe we should consider changing the flag readonly to opt-in rather than opt-out.