### PR TITLE
meson: Check if d3d9 is enabled too.

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -4,8 +4,8 @@ subdir('vulkan')
 subdir('dxvk')
 
 if get_option('enable_dxgi')
-  if not get_option('enable_d3d10') and not get_option('enable_d3d11')
-    error('D3D10 and/or D3D11 required for DXGI to properly functionning.')
+  if not get_option('enable_d3d9') and not get_option('enable_d3d10') and not get_option('enable_d3d11')
+    error('D3D9, D3D10 and/or D3D11 required for DXGI to properly functionning.')
   endif
   subdir('dxgi')
 endif


### PR DESCRIPTION
Fixes the build when both `enable_d3d10` and `enable_d3d11` are set to false.
```
src/meson.build:8:4: ERROR: Problem encountered: D3D10 and/or D3D11 required for DXGI to properly functionning.
```
Also see https://github.com/Joshua-Ashton/d9vk/issues/398.