### PR TITLE
[util] Force vendorId and deviceId for Halo CE

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -216,6 +216,21 @@ namespace dxvk {
     { R"(\\halo2\.exe$)", {{
       { "d3d9.invariantPosition",           "True" },
     }} },
+    /* Halo CE/HaloPC
+       Regex forced case insensitive as some
+       distributions come with all caps filenames.*/
+    { R"(\\(?i)(halo|haloce)\.exe)", {{
+      // Game enables minor decal layering fixes
+      // specifically when it detects AMD.
+      // Avoids chip being detected as unsupported
+      // when on intel. Avoids possible path towards
+      // invalid texture addressing methods.
+      { "d3d9.customVendorId",              "1002" },
+      // Avoids card not recognized error.
+      // Keeps game's rendering methods consistent
+      // for optimal compatibility.
+      { "d3d9.customDeviceId",              "4172" },
+    }} },
     /* Counter Strike: Global Offensive
        Needs NVAPI to avoid a forced AO + Smoke
        exploit so we must force AMD vendor ID.    */


### PR DESCRIPTION
Based on the default config, and gamecode this is the best option for this game as it avoids workarounds that were specifically designed for old GPUs that on modern day hardware and in d9vk break rendering. (tested on multiple sets of hardware and software configurations).

The vendor is set to AMD as:
 - It enables a few AMD specific decal layering fixes that are needed on all hardware.
 - It avoids certain invalid rendering methods.
 - It avoids the game's rendering being affected when it detects Intel graphics hardware.
 - It avoids a sometimes confusing error on startup.
 - It avoids the need of common text file tweaks while not breaking configurations that were tweaked this way.

The game has a lot of hardware specific workarounds that can cause random compatibility issues with d9vk. This will avoid that.