### PR TITLE
[util] Fix broken regex in config.cpp

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -217,9 +217,8 @@ namespace dxvk {
       { "d3d9.invariantPosition",           "True" },
     }} },
     /* Halo CE/HaloPC
-       Regex forced case insensitive as some
-       distributions come with all caps filenames.*/
-    { R"(\\(?i)(halo|haloce)\.exe)", {{
+       Some distributions come with all caps filenames.*/
+    { R"(\\(halo\.exe|haloce\.exe|HALO\.EXE|HALOCE\.EXE)", {{
       // Game enables minor decal layering fixes
       // specifically when it detects AMD.
       // Avoids chip being detected as unsupported


### PR DESCRIPTION
The one time I don't check stuff I break something on a colossal level. I got cocky.

That is valid syntax in like only one flavor of regex.

I'm embarrassed of myself.